### PR TITLE
Add memcpy tests, fix incorrect return value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,8 +291,8 @@ $(ODIR)/test/test: lib $(TEST_OBJECTS) $(LD_SCRIPT)
 	$(Q)$(CC) $(CFLAGS) $(CFLAGS_LD) -Wl,-Map=$@.map  -Wl,-T $(LD_SCRIPT) \
 	      $(TEST_OBJECTS) -o $@ $(NOC_LD_NAME)
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $@.lst
-	$(Q)strip --strip-all $@
-	$(Q)ls -al $@
+	$(Q)strip --strip-unneeded $@ -o $@.clean
+	$(Q)ls -al $@ $@.clean
 
 clean:
 	rm -rf ./build

--- a/platform/x86_64-pc-linux-gnu.ld
+++ b/platform/x86_64-pc-linux-gnu.ld
@@ -21,6 +21,7 @@ PHDRS
 	text PT_LOAD;
   /* data PT_LOAD; */
 	bss PT_LOAD;
+  tls PT_TLS;
 }
 
 SECTIONS
@@ -87,10 +88,6 @@ SECTIONS
     *(.data .data.* .gnu.linkonce.d.* .data1)
     *(.sdata .sdata.* .sdata2.*)
     *(.ldata .ldata.* .gnu.linkonce.l.*)
-    /* TODO: Provide threads support? */
-    PROVIDE(__tdata_start = .);
-    *(.tdata .tdata.*)
-    PROVIDE(__tdata_end = .);
      /* Place zero word at the end */
     LONG(0)
     . = ALIGN(16);
@@ -99,22 +96,34 @@ SECTIONS
   PROVIDE(_data_start = ADDR(.data));
   PROVIDE(_data_source = LOADADDR(.data));
 
-  .bss (NOLOAD) :
-  {
+  .tdata : {
+    /* TODO: Provide threads support? */
+    PROVIDE(__tdata_start = .);
+    *(.tdata .tdata.*)
+    PROVIDE(__tdata_end = .);
+   . = ALIGN(8);
+  } > RAM AT>RAM :tls
+
+  .tbss (NOLOAD) : {
+    /* TODO: Provide threads support? */
+    PROVIDE(__tbss_start = .);
+    *(.tbss .tbss.*)
+    PROVIDE(__tbss_end = .);
+   . = ALIGN(8);
+  } > RAM AT>RAM :tls
+
+  .bss (NOLOAD) : {
     _bss_start = .;
     *(.dynbss)
     *(.bss .bss.* .gnu.linkonce.b.*)
     *(.dynlbss)
     *(.lbss .lbss.* .gnu.linkonce.lb.*)
-    /* TODO: Provide threads support? */
-    PROVIDE(__tbss_start = .);
-    *(.tbss .tbss.*)
-    PROVIDE(__tbss_end = .);
     *(COMMON)
     *(LARGE_COMMON)
    . = ALIGN(8);
     _bss_end = .;
   } > RAM AT>RAM :bss
+
   PROVIDE( _bss_size = _bss_end - _bss_start );
   PROVIDE (_brk_start = .);
   PROVIDE (_brk_end = LENGTH(RAM) + ORIGIN(RAM));

--- a/src/memcpy.c
+++ b/src/memcpy.c
@@ -12,8 +12,10 @@
 
 #if defined(ARCH_X86_64)
 void *memcpy(void *restrict dest, const void *restrict src, size_t len) {
-    __asm__("rep movsb\n" : : "D"(dest), "S"(src), "c"(len) :);
-    return dest;
+    void *dest_copy = dest;
+    // Workaround for Clang 14/15 which thinks rdi/rsi/rcx aren't changed
+    __asm__ volatile ("rep movsb\n" : "+D"(dest), "+S"(src), "+c"(len) : : "memory");
+    return dest_copy;
 }
 #else
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -131,24 +131,29 @@ bool is_test_succeed(void);
                     expect, tolerance,                                     \
                     (struct test_flags){.near = 1, .sign = 1});
 
+// Type checking cast pointer to uintptr_t
+static inline uintptr_t noc_ptr_to_uint(const void* ptr) {
+    return (uintptr_t)ptr;
+}
+
 // Check if two pointers are equal
-#define TEST_PTR_EQ(got, expect)                                     \
-    add_test_result(__LINE__, #got " == " #expect, (uintptr_t)(got), \
-                    (uintptr_t)(expect), 0, (struct test_flags){.ptr = 1})
+#define TEST_PTR_EQ(got, expect)                                         \
+    add_test_result(__LINE__, #got " == " #expect, noc_ptr_to_uint(got), \
+                    noc_ptr_to_uint(expect), 0, (struct test_flags){.ptr = 1})
 
 // Check if two pointers are unequal
-#define TEST_PTR_NEQ(got, expect)                                    \
-    add_test_result(__LINE__, #got " != " #expect, (uintptr_t)(got), \
-                    (uintptr_t)(expect), 0,                          \
+#define TEST_PTR_NEQ(got, expect)                                        \
+    add_test_result(__LINE__, #got " != " #expect, noc_ptr_to_uint(got), \
+                    noc_ptr_to_uint(expect), 0,                          \
                     (struct test_flags){.ptr = 1, .invert = 1})
 
 // Check if a pointer is NULL
-#define TEST_PTR_NULL(got)                                       \
-    add_test_result(__LINE__, #got " == NULL", (uintptr_t)(got), \
+#define TEST_PTR_NULL(got)                                           \
+    add_test_result(__LINE__, #got " == NULL", noc_ptr_to_uint(got), \
                     (uintptr_t)NULL, 0, (struct test_flags){.ptr = 1})
-#define TEST_PTR_NONNULL(got)                                    \
-    add_test_result(__LINE__, #got " != NULL", (uintptr_t)(got), \
-                    (uintptr_t)NULL, 0,                          \
+#define TEST_PTR_NONNULL(got)                                        \
+    add_test_result(__LINE__, #got " != NULL", noc_ptr_to_uint(got), \
+                    (uintptr_t)NULL, 0,                              \
                     (struct test_flags){.ptr = 1, .invert = 1})
 
 // Check something is zero
@@ -166,26 +171,27 @@ bool is_test_succeed(void);
                     (struct test_flags){.is_true = 1, .invert = 1})
 
 // Check if two strings are equal, like strcmp().
-#define TEST_STR_EQ(got, expect)                                     \
-    add_test_result(__LINE__, #got " == " #expect, (uintptr_t)(got), \
-                    (uintptr_t)(expect), -1, (struct test_flags){.str = 1})
+#define TEST_STR_EQ(got, expect)                                         \
+    add_test_result(__LINE__, #got " == " #expect, noc_ptr_to_uint(got), \
+                    noc_ptr_to_uint(expect), -1,                         \
+                    (struct test_flags){.str = 1})
 
 // Check if two strings are equal in the first len chars, like strncmp().
-#define TEST_STRN_EQ(got, expect, len)                               \
-    add_test_result(__LINE__, #got " == " #expect, (uintptr_t)(got), \
-                    (uintptr_t)(expect), len, (struct test_flags){.str = 1})
+#define TEST_STRN_EQ(got, expect, len)                                   \
+    add_test_result(__LINE__, #got " == " #expect, noc_ptr_to_uint(got), \
+                    noc_ptr_to_uint(expect), len,                        \
+                    (struct test_flags){.str = 1})
 
 // Check if two memory buffers are equal, like memcmp().
-#define TEST_MEMCMP(got, expect, len)                                \
-    add_test_result(__LINE__, #got " == " #expect, (uintptr_t)(got), \
-                    (uintptr_t)(expect), len,                        \
+#define TEST_MEMCMP(got, expect, len)                                     \
+    add_test_result(__LINE__, #got " == " #expect, noc_ptr_to_uint(got),  \
+                    noc_ptr_to_uint(expect), len,                         \
                     (struct test_flags){.memcmp = 1})
 
 // Check if memory buffer is set to value, like memchk().
-#define TEST_MEMCHK(got, expect, len)                                \
-    add_test_result(__LINE__, #got " == " #expect, (uintptr_t)(got), \
-                    (uintptr_t)(expect), len,                        \
-                    (struct test_flags){.memchk = 1})
+#define TEST_MEMCHK(got, expect, len)                                    \
+    add_test_result(__LINE__, #got " == " #expect, noc_ptr_to_uint(got), \
+                    (uint8_t)(expect), len, (struct test_flags){.memchk = 1})
 
 struct test_case {
     // Test case name. Case-insensitive.

--- a/test/test_memcpy.c
+++ b/test/test_memcpy.c
@@ -1,0 +1,150 @@
+// Copyright 2022 Vadim Sukhomlinov
+
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "noc_internal/common.h"
+#include "test_common.h"
+
+// Buffers used for testing.
+uint32_t s_buf[768];
+uint32_t s2_buf[768];
+uint32_t d_buf[768];
+
+// The 32 bit LFSR whose maximum length feedback polynomial is represented
+// as X^32 + X^22 + X^2 + X^1 + 1 will produce 2^32-1 PN sequence.
+// This LFSR can be initialized with 0,  but can't be initialized with
+// 0xFFFFFFFF
+static uint32_t lfsr32(uint32_t seed) {
+    uint32_t mask = (-((int32_t)seed >= 0)) & 0xC0000401;
+    return (seed << 1) ^ mask;
+}
+
+// Testing memory copy/move operations is a bit tricky and requires known
+// patterns to be sure that data was copied as expected. Simple patterns
+// don't work as logical errors may result in copying same data twice in
+// different location or in wrong location.
+// Use pseudo-random patterns with provided seed. Exact copy should have
+// all elements equal. Wipes should result in most elements not equal.
+
+// Fill buffer with pseudo-random pattern.
+static void fill_rand(void *buf, uint32_t seed, size_t len) {
+    uint8_t *ptr = (uint8_t *)buf;
+
+    while (len) {
+        size_t remaining_seed = sizeof(seed);
+        uint32_t c_seed = seed;
+        seed = lfsr32(seed);
+
+        while (remaining_seed != 0 && len > 0) {
+            *ptr = c_seed & 0xff;
+            c_seed >>= 8;
+            ptr++;
+            len--;
+            remaining_seed--;
+        };
+    }
+}
+
+// Count matches with specific pseudo-random pattern.
+static size_t count_rand_equal(const void *buf, uint32_t seed, size_t len) {
+    size_t count = 0;
+    uint8_t *ptr = (uint8_t *)buf;
+
+    while (len) {
+        size_t remaining_seed = sizeof(seed);
+        uint32_t c_seed = seed;
+        seed = lfsr32(seed);
+
+        while (remaining_seed != 0 && len > 0) {
+            if (*ptr == (c_seed & 0xff)) count++;
+            c_seed >>= 8;
+            ptr++;
+            len--;
+            remaining_seed--;
+        };
+    }
+    return count;
+}
+
+static bool memcpy_smoke_test(void) {
+    fill_rand(s_buf, 0, sizeof(s_buf));
+    fill_rand(d_buf, 10, sizeof(d_buf));
+    TEST_EQ(count_rand_equal(s_buf, 0, sizeof(s_buf)), sizeof(s_buf));
+    TEST_EQ(count_rand_equal(d_buf, 10, sizeof(d_buf)), sizeof(d_buf));
+    TEST_NEQ(count_rand_equal(d_buf, 0, sizeof(d_buf)), sizeof(d_buf));
+
+    // smoke test memcpy() works
+    TEST_PTR_EQ(memcpy(d_buf, s_buf, sizeof(d_buf)), ((void *)d_buf));
+    TEST_EQ(count_rand_equal(d_buf, 0, sizeof(d_buf)), sizeof(d_buf));
+
+    fill_rand(s_buf, 0, sizeof(s_buf));
+    fill_rand(d_buf, 10, sizeof(d_buf));
+    TEST_PTR_EQ(memcpy(d_buf, s_buf, 7), ((void *)d_buf));
+    TEST_EQ(count_rand_equal(d_buf, 0, 7), 7);
+
+    return is_test_succeed();
+}
+DECLARE_TEST(memcpy_smoke_test);
+
+// Test various memory sizes, aligned.
+static bool memcpy_aligned_test(void) {
+    for (size_t i = 1; i <= sizeof(d_buf); i++) {
+        // first, clean up
+        fill_rand(s_buf, 0x11111111, sizeof(s_buf));
+        fill_rand(s_buf, 0x23456789, i);
+        fill_rand(d_buf, 0x33333333, i);
+
+        TEST_PTR_EQ(memcpy(d_buf, s_buf, i), d_buf);
+        TEST_EQ(count_rand_equal(d_buf, 0x23456789, i), i);
+        TEST_MEMCMP(d_buf, s_buf, i);
+
+        d_buf[((i - 1) / sizeof(uint32_t))] ^= 0x01010101;
+        TEST_NEQ(memcmp(d_buf, s_buf, i), 0);
+    }
+    return is_test_succeed();
+}
+DECLARE_TEST(memcpy_aligned_test);
+
+
+// Test various memory sizes, unaligned
+static bool memcpy_unaligned_test(void) {
+    for (size_t sa = 0; sa < sizeof(uintptr_t); sa++)
+        for (size_t da = 0; da < sizeof(uintptr_t); da++) {
+            uint8_t *d = (uint8_t *)d_buf;
+            uint8_t *s = (uint8_t *)s_buf;
+
+            size_t copy_size = sizeof(d_buf) - sa - da;
+
+            // make tests a bit faster for expected byte copies
+            if (sa != da) {
+                copy_size >>= 2;
+            }
+
+            d += da;
+            s += sa;
+            for (size_t i = 1; i <= copy_size; i += 13) {
+                // initialize with specific pseudo-random pattern
+                fill_rand(s, 0x11111111, copy_size);
+                fill_rand(s, 0x12345678, i);
+                fill_rand(d, 0x33333333, i);
+
+                TEST_PTR_EQ(memcpy(d, s, i), d);
+                // d should be exactly 's'
+                TEST_EQ(count_rand_equal(d, 0x12345678, i), i);
+
+                TEST_INT_EQ(memcmp(d, s, i), 0);
+
+                d[i - 1] ^= 1;
+                TEST_INT_NEQ(memcmp(d, s, i), 0);
+            }
+        }
+
+    return is_test_succeed();
+}
+DECLARE_TEST(memcpy_unaligned_test);


### PR DESCRIPTION
1. Fix linker script with separating TLS sections which otherwise caused issues with permissions.
2. Fix x86_64 asm for memcpy to return correct value
3. Added tests for memcpy and memcmp