### PR TITLE
Fix compiler warnings and binary size issue

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -159,6 +159,14 @@ size_t strxfrm(char *restrict s1, const char *restrict s2, size_t n);
 /// @defgroup g3 Search functions.
 /// @{
 
+/// The rawmemchr() function is similar to memchr(): it assumes (i.e., the
+/// programmer knows for certain) that an instance of c lies somewhere in the
+/// memory area starting at the location pointed to by s, and so performs an
+/// optimized search for c (i.e., no use of a count argument to limit the range
+/// of the search). If an instance of c is not found, the results are
+/// unpredictable.
+void *rawmemchr(const void *s, int c);
+
 /// @brief Find first occurence of character.
 ///
 /// The memchr function locates the first occurrence of `c` (converted to an
@@ -173,6 +181,16 @@ size_t strxfrm(char *restrict s1, const char *restrict s2, size_t n);
 /// does not occur in the object.
 const void *memchr(const void *buffer, int c, size_t n);
 
+/// @brief Find last occurence of character (reverse search).
+///
+/// The memchr function locates the last occurrence of `c` (converted to an
+/// unsigned char) in the initial `n` characters (each interpreted as unsigned
+/// char) of the object pointed to by `buffer`.
+/// @param buffer source buffer
+/// @param c character to search
+/// @param n length of buffer
+/// @return pointer to the located character, or a null pointer if the character
+/// does not occur in the object.
 const void *memrchr(const void *buffer, int c, size_t n);
 
 /// @brief Find first occurence of character in null-terminated string.
@@ -184,32 +202,56 @@ const void *memrchr(const void *buffer, int c, size_t n);
 /// @param c character to search
 /// @return returns a pointer to the located character, or a null pointer if the
 /// character does not occur in the string.
-char *strchr(const char *s, int c);
+const char *strchr(const char *s, int c);
 
-///@brief Search for first character from the list.
+/// @brief Search for first character from the list.
 /// The strcspn function computes the length of the maximum initial segment of
 /// the string pointed to by `s` which consists entirely of characters not from
 /// the string pointed to by `characters`.
-///@param s pointer to the null-terminated byte string to be analyzed
-///@param characters pointer to the null-terminated byte string that contains
+/// @param s pointer to the null-terminated byte string to be analyzed
+/// @param characters pointer to the null-terminated byte string that contains
 /// the characters to search for
 ///@return length of the maximum initial segment
 size_t strcspn(const char *s, const char *characters);
 
-///@brief Search for first character not from the list.
+/// @brief Search for first character not from the list.
 /// The strspn function computes the length of the maximum initial segment of
 /// the string pointed to by `s` which consists entirely of characters from
 /// the string pointed to by `characters`.
-///@param s pointer to the null-terminated byte string to be analyzed
-///@param characters pointer to the null-terminated byte string that contains
+/// @param s pointer to the null-terminated byte string to be analyzed
+/// @param characters pointer to the null-terminated byte string that contains
 /// the characters to search for.
 ///@return length of the maximum initial segment
 size_t strspn(const char *s, const char *characters);
 
-char *strpbrk(const char *s1, const char *s2);
+/// @brief Locates the first occurrence of character in the string
+/// The strpbrk function locates the first occurrence in the string
+/// pointed to by s of any character from the string pointed to by characters.
+/// @param s pointer to the null-terminated byte string to be analyzed
+/// @param characters pointer to the null-terminated byte string that contains
+/// the characters to search for.
+/// @return a pointer to the character, or a null pointer if no character from characters
+/// occurs in s
+char *strpbrk(const char *s, const char *characters);
 
+/// @brief Locates the last occurrence of character in the string
+/// The strrchr generic function locates the last occurrence of c (converted to
+/// a char) in the string pointed to by s. The terminating null character is
+/// considered to be part of the string.
+/// @param s pointer to the null-terminated byte string to be analyzed
+/// @param c character to search
+/// @return a pointer to the character, or a null pointer if c does not occur in the string.
 char *strrchr(const char *s, int c);
 
+/// @brief Locates the first occurrence of the null-terminated string s2 in the
+/// null-terminated string s1. The strstr generic function locates the first
+/// occurrence in the string pointed to by s1 of the sequence of characters
+/// (excluding the terminating null character) in the string pointed to by s2.
+/// @param s1 pointer to the null-terminated byte string to be analyzed
+/// @param s2 pointer to the null-terminated byte string to search for
+/// @return The strstr generic function returns a pointer to the located string,
+/// or a null pointer if the string is not found. If s2 points to a string with
+/// zero length, the function returns s1.
 char *strstr(const char *s1, const char *s2);
 
 /// @}

--- a/platform/x86_64-pc-linux-gnu.ld
+++ b/platform/x86_64-pc-linux-gnu.ld
@@ -102,7 +102,7 @@ SECTIONS
     *(.tdata .tdata.*)
     PROVIDE(__tdata_end = .);
    . = ALIGN(8);
-  } > RAM AT>RAM :tls
+  } > RAM AT>ROM :tls
 
   .tbss (NOLOAD) : {
     /* TODO: Provide threads support? */
@@ -110,7 +110,7 @@ SECTIONS
     *(.tbss .tbss.*)
     PROVIDE(__tbss_end = .);
    . = ALIGN(8);
-  } > RAM AT>RAM :tls
+  } > RAM AT>ROM :tls
 
   .bss (NOLOAD) : {
     _bss_start = .;

--- a/src/strmem.c
+++ b/src/strmem.c
@@ -49,6 +49,18 @@ char *strzcpy(char *dest, const char *src, size_t len) {
     return dest;
 }
 
+/// The rawmemchr() function is similar to memchr(): it assumes (i.e., the
+/// programmer knows for certain) that an instance of c lies somewhere in the
+/// memory area starting at the location pointed to by s, and so performs an
+/// optimized search for c (i.e., no use of a count argument to limit the range
+/// of the search). If an instance of c is not found, the results are
+/// unpredictable.
+void *rawmemchr(const void *s, int c) {
+    const char *scan = (const char *)s;
+    while (*scan != c) scan++;
+    return (void *)scan;
+}
+
 const void *memchr(const void *buffer, int c, size_t n) {
     const char *current = (char *)buffer;
     // Adjust n to avoid address wrapping
@@ -57,6 +69,16 @@ const void *memchr(const void *buffer, int c, size_t n) {
     while (current < end) {
         if (*current == c) return current;
         current++;
+    }
+    return NULL;
+}
+
+// Find first occurence of character in null-terminated string.
+const char *strchr(const char *s, int c) {
+    if (!s) return s;
+    while (*s) {
+        if (*s == c) return s;
+        s++;
     }
     return NULL;
 }
@@ -123,4 +145,55 @@ int strncmp(const char *s1, const char *s2, size_t len) {
     } while ((c1 == c2) && c1 && s1 < s1_end);
 
     return (int)c1 - (int)c2;
+}
+
+// Search for first character from the list
+char *strpbrk(const char *s, const char *accept) {
+    if (!s) return NULL;
+    if (!accept) return (char *)s;
+    while (*s) {
+        const char *a = accept;
+        while (*a) {
+            if (*a == *s) return (char *)s;
+            a++;
+        }
+        s++;
+    }
+    return NULL;
+}
+
+// Search for first character from the list.
+size_t strcspn(const char *s, const char *characters) {
+    if (!s) return 0;
+    if (!characters) return strlen(s);
+    const char *start = s;
+    while (*s) {
+        const char *a = characters;
+        while (*a) {
+            if (*a == *s) return (size_t)(s - start);
+            a++;
+        }
+        s++;
+    }
+    return (size_t)(s - start);
+}
+
+/// Locates the first occurrence of the null-terminated string s2 in the
+/// null-terminated string s1. The strstr generic function locates the first
+/// occurrence in the string pointed to by s1 of the sequence of characters
+/// (excluding the terminating null character) in the string pointed to by s2.
+/// @param s1 pointer to the null-terminated byte string to be analyzed
+/// @param s2 pointer to the null-terminated byte string to search for
+/// @return The strstr generic function returns a pointer to the located string,
+/// or a null pointer if the string is not found. If s2 points to a string with
+/// zero length, the function returns s1.
+char *strstr(const char *s1, const char *s2) {
+    if (!s1) return NULL;
+    size_t len = strlen(s2);
+    if (!len) return (char *)s1;
+    while (*s1) {
+        if (!memcmp(s1, s2, len)) return (char *)s1;
+        s1++;
+    }
+    return NULL;
 }

--- a/test/test_snprintf.c
+++ b/test/test_snprintf.c
@@ -65,7 +65,11 @@ static bool test_snprintf(void) {
     TEST_SNPRINTF("1234567890", "%d", 1234567890);
 
     // Unsupported format
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
     TEST_INT_EQ(snprintf(s, sizeof(s), "%z", 1234567890), -1);
+#pragma GCC diagnostic pop
 
     TEST_SNPRINTF("1234567890 499602d2 011145401322 A Hello", "%d %x %o %c %s",
                   1234567890, 1234567890, 1234567890, 'A', "Hello");


### PR DESCRIPTION
1. Fixed strpbrk signature to match the declaration in C standard and headers.
2. Suppressed -Wformat warning for unsupported %z format test in snprintf tests.
3. Fixed massive linker padding bug by changing AT>RAM to AT>ROM for .tdata and .tbss sections.