### PR TITLE
Add assert.h and abort() implementation

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -1,0 +1,59 @@
+// Copyright 2024 Vadim Sukhomlinov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+/// @file assert.h
+/// @brief Runtime and static assertions. Subset of `assert.h` from C standard
+/// library.
+
+#undef assert
+
+#ifdef NDEBUG
+#define assert(expr) ((void)0)
+#else
+
+#ifndef NOC_ASSERT_H_DECLS
+#define NOC_ASSERT_H_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @brief Called when assertion fails.
+/// @param expr The stringified expression that failed.
+/// @param file The filename where the assertion occurred.
+/// @param line The line number where the assertion occurred.
+/// @param func The function name where the assertion occurred (or NULL).
+void __assert_fail(const char *expr, const char *file, int line,
+                   const char *func) __attribute__((noreturn));
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // NOC_ASSERT_H_DECLS
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define assert(expr) \
+    ((expr) ? (void)0 : __assert_fail(#expr, __FILE__, __LINE__, __func__))
+#else
+#define assert(expr) \
+    ((expr) ? (void)0 : __assert_fail(#expr, __FILE__, __LINE__, 0))
+#endif
+
+#endif  // NDEBUG
+
+#ifndef NOC_ASSERT_H
+#define NOC_ASSERT_H
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#ifndef static_assert
+#define static_assert static_assert
+#endif
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#ifndef static_assert
+#define static_assert _Static_assert
+#endif
+#endif
+
+#endif /* NOC_ASSERT_H */

--- a/src/abort.c
+++ b/src/abort.c
@@ -1,0 +1,9 @@
+// Copyright 2024 Vadim Sukhomlinov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <stdlib.h>
+
+__attribute__((weak)) void abort(void) { __builtin_trap(); }

--- a/src/assert.c
+++ b/src/assert.c
@@ -1,0 +1,20 @@
+// Copyright 2024 Vadim Sukhomlinov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__attribute__((weak)) void __assert_fail(const char *expr, const char *file,
+                                         int line, const char *func) {
+    if (func) {
+        printf("Assertion failed: %s, file %s, line %d, function %s\n", expr,
+               file, line, func);
+    } else {
+        printf("Assertion failed: %s, file %s, line %d\n", expr, file, line);
+    }
+    abort();
+}

--- a/test/test_assert.c
+++ b/test/test_assert.c
@@ -1,0 +1,26 @@
+// Copyright 2024 Vadim Sukhomlinov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "test_common.h"
+
+static bool test_assert(void) {
+    // We only test the success path because a failed assert is marked
+    // 'noreturn' and would call abort(), terminating the test runner.
+    // Testing the failure path would require setjmp/longjmp, which
+    // is currently not implemented in this library.
+
+    assert(1 == 1);
+    assert(2 + 2 == 4);
+
+    static_assert(sizeof(char) == 1, "char size is not 1");
+
+    return true;
+}
+
+DECLARE_TEST(test_assert);


### PR DESCRIPTION
- Added subset of standard C assert.h.
- Implemented __assert_fail and weak abort() via __builtin_trap().
- Added test_assert to verify basic compilation and success paths.